### PR TITLE
Update compose.yaml

### DIFF
--- a/media/compose.yaml
+++ b/media/compose.yaml
@@ -29,7 +29,6 @@ services:
       servarrnetwork:
         ipv4_address: 172.39.0.2
     ports:
-      - ${FIREWALL_VPN_INPUT_PORTS}:${FIREWALL_VPN_INPUT_PORTS} # airvpn forwarded port, pulled from .env
       - 8080:8080 # qbittorrent web interface
       - 6881:6881 # qbittorrent torrent port
       - 6789:6789 # nzbget


### PR DESCRIPTION
Removed FIREWALL_INPUT_PORTS from ports definition in gluetun. It does not belong there. Only in the environment variable. This tells gluetun to open it's firewall for that port, allowing the forwarded port from ivpn into the gluetun network.

Ports section is ONLY to forward local lan connections into the container network. It should not contain external port definitions.